### PR TITLE
[HC-2318] 貨態追蹤語言支援中文

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dhl-express (0.1.0)
+    dhl-express (0.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -167,7 +167,10 @@ response = Dhl::Express::Methods.new(dhl_client).create_shipment(data)
 data = {
   shipmentTrackingNumber: [0987654321],
 }
-response = Dhl::Express::Methods.new(dhl_client).track_shipments
+headers = {
+  "Accept-Language": "chi", # Format {3-character language code}
+}
+response = Dhl::Express::Methods.new(dhl_client).track_shipments(data, headers)
 ```
 
 #### Cancel a pickup booking request

--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ response = Dhl::Express::Methods.new(dhl_client).create_shipment(data)
 data = {
   shipmentTrackingNumber: [0987654321],
 }
-headers = {
-  "Accept-Language": "chi", # Format {3-character language code}
-}
-response = Dhl::Express::Methods.new(dhl_client).track_shipments(data, headers)
+language = "chi" # Format {3-character language code}
+# If language is empty, default language is English.
+
+response = Dhl::Express::Methods.new(dhl_client).track_shipments(data, language)
 ```
 
 #### Cancel a pickup booking request

--- a/lib/dhl/express/api.rb
+++ b/lib/dhl/express/api.rb
@@ -20,10 +20,10 @@ module Dhl
         end
       end
 
-      def get(auth, request_params, path)
+      def get(auth, request_params, path, headers = {})
         uri = URI("#{api_base_url}#{path}?#{URI.encode_www_form(request_params)}")
         http = init_http(uri)
-        request = Net::HTTP::Get.new(uri.request_uri)
+        request = headers.empty? ? Net::HTTP::Get.new(uri.request_uri) : Net::HTTP::Get.new(uri.request_uri, headers)
         request.basic_auth(auth[:username], auth[:password])
         http.request(request)
       end

--- a/lib/dhl/express/methods.rb
+++ b/lib/dhl/express/methods.rb
@@ -6,6 +6,8 @@ module Dhl
 
     class Methods
 
+      KEYS_OF_HEADERS = %i[Accept-Language]
+
       KEYS_OF_RETRIEVE_RATES_FOR_ONE_PIECE = %i[
         accountNumber originCountryCode originPostalCode originCityName destinationCountryCode destinationPostalCode
         destinationCityName weight length width height plannedShippingDate isCustomsDeclarable unitOfMeasurement
@@ -54,10 +56,11 @@ module Dhl
         dhl_api.post({ username: client.username, password: client.password }, request_params, path)
       end
 
-      def track_shipments(data)
+      def track_shipments(data, header_options = {})
         path = "/tracking"
         request_params = data.slice(*KEYS_OF_TRACK_SHIPMENTS)
-        dhl_api.get({ username: client.username, password: client.password }, request_params, path)
+        headers = header_options.slice(*KEYS_OF_HEADERS)
+        dhl_api.get({ username: client.username, password: client.password }, request_params, path, headers)
       end
 
       def cancel_pickup(data)

--- a/lib/dhl/express/methods.rb
+++ b/lib/dhl/express/methods.rb
@@ -6,8 +6,6 @@ module Dhl
 
     class Methods
 
-      KEYS_OF_HEADERS = %i[Accept-Language]
-
       KEYS_OF_RETRIEVE_RATES_FOR_ONE_PIECE = %i[
         accountNumber originCountryCode originPostalCode originCityName destinationCountryCode destinationPostalCode
         destinationCityName weight length width height plannedShippingDate isCustomsDeclarable unitOfMeasurement
@@ -56,10 +54,10 @@ module Dhl
         dhl_api.post({ username: client.username, password: client.password }, request_params, path)
       end
 
-      def track_shipments(data, header_options = {})
+      def track_shipments(data, language = "eng")
         path = "/tracking"
         request_params = data.slice(*KEYS_OF_TRACK_SHIPMENTS)
-        headers = header_options.slice(*KEYS_OF_HEADERS)
+        headers = { "Accept-Language": language }
         dhl_api.get({ username: client.username, password: client.password }, request_params, path, headers)
       end
 

--- a/lib/dhl/express/version.rb
+++ b/lib/dhl/express/version.rb
@@ -4,7 +4,7 @@ module Dhl
 
   module Express
 
-    VERSION = "0.1.0"
+    VERSION = "0.1.2"
 
   end
 

--- a/spec/dhl/methods_spec.rb
+++ b/spec/dhl/methods_spec.rb
@@ -60,17 +60,17 @@ RSpec.describe Dhl::Express::Methods do
   end
 
   describe "#track_shipments" do
-    subject { described_class.new(client).track_shipments(data, headers) }
+    subject { described_class.new(client).track_shipments(data, language) }
 
     let(:data) { { shipmentTrackingNumber: %w[123 456] } }
-    let(:headers) { { "Accept-Language": "eng", "unwanted": "header" } }
+    let(:language) { "chi" }
 
     before do
       expect_any_instance_of(Dhl::Express::Api).to receive(:get).with(
         { username: "username", password: "password" },
         { shipmentTrackingNumber: %w[123 456] },
         "/tracking",
-        { "Accept-Language": "eng" },
+        { "Accept-Language": "chi" },
       ).and_return("success_response")
     end
 

--- a/spec/dhl/methods_spec.rb
+++ b/spec/dhl/methods_spec.rb
@@ -60,15 +60,17 @@ RSpec.describe Dhl::Express::Methods do
   end
 
   describe "#track_shipments" do
-    subject { described_class.new(client).track_shipments(data) }
+    subject { described_class.new(client).track_shipments(data, headers) }
 
     let(:data) { { shipmentTrackingNumber: %w[123 456] } }
+    let(:headers) { { "Accept-Language": "eng", "unwanted": "header" } }
 
     before do
       expect_any_instance_of(Dhl::Express::Api).to receive(:get).with(
         { username: "username", password: "password" },
         { shipmentTrackingNumber: %w[123 456] },
         "/tracking",
+        { "Accept-Language": "eng" },
       ).and_return("success_response")
     end
 


### PR DESCRIPTION
## 需求來源

https://sinlead.atlassian.net/browse/HC-2318

## 功能/問題描述

依照 dhl 文件貨態追蹤支援中文要特別傳入 header 
https://developer.dhl.com/api-reference/dhl-express-mydhl-api#operations-tracking-exp-api-shipments-tracking-multi

## 作法

```
Dhl::Express::Methods.new(dhl_client).track_shipments(data, "chi")
```
